### PR TITLE
Add function to get all items from a playlist

### DIFF
--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -714,6 +714,63 @@ class Api(object):
         else:
             return PlaylistItemListResponse.from_dict(res_data)
 
+    def get_playlist_all_items(
+        self,
+        *,
+        playlist_id: str,
+        parts: Optional[Union[str, list, tuple, set]] = None,
+        video_id: Optional[str] = None,
+        count: Optional[int] = 5,
+        return_json: Optional[bool] = False,
+    ):
+        """
+        Retrieve all playlist Items info by your given playlist id
+
+        Args:
+            playlist_id (str):
+                The id for playlist that you want to retrieve items data.
+            parts ((str,list,tuple,set) optional):
+                The resource parts for you want to retrieve.
+                If not provide, use default public parts.
+                You can pass this with single part str, comma-separated parts str or a list,tuple,set of parts.
+            video_id (str, Optional):
+                Specifies that the request should return only the playlist items that contain the specified video.
+            count (int, optional):
+                Control how many items per page will be retreived.
+                Default is 5.
+            return_json(bool, optional):
+                The return data type. If you set True JSON data will be returned.
+                False will return a pyyoutube.PlayListItemApiResponse instance.
+        Returns:
+            PlaylistItemListResponse or original data
+        """
+        args = {
+            "playlistId": playlist_id,
+            "part": enf_parts(resource="playlistItems", value=parts),
+            "maxResults": count,
+        }
+        if video_id is not None:
+            args["video_id"] = video_id
+
+        res_data: Optional[dict] = None
+        current_items: List[dict] = []
+        next_page_token: Optional[str] = None
+        while True:
+            prev_page_token, next_page_token, data = self.paged_by_page_token(
+                resource="playlistItems", args=args, page_token=next_page_token
+            )
+            items = self._parse_data(data)
+            current_items.extend(items)
+            if res_data is None:
+                res_data = data
+            if next_page_token is None:
+                break
+
+        res_data["items"] = current_items
+        if not return_json:
+            res_data = PlaylistItemListResponse.from_dict(res_data)
+        return res_data
+
     def get_video_by_id(
         self,
         *,

--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -723,63 +723,6 @@ class Api(object):
         else:
             return PlaylistItemListResponse.from_dict(res_data)
 
-    def get_playlist_all_items(
-        self,
-        *,
-        playlist_id: str,
-        parts: Optional[Union[str, list, tuple, set]] = None,
-        video_id: Optional[str] = None,
-        count: Optional[int] = 5,
-        return_json: Optional[bool] = False,
-    ):
-        """
-        Retrieve all playlist Items info by your given playlist id
-
-        Args:
-            playlist_id (str):
-                The id for playlist that you want to retrieve items data.
-            parts ((str,list,tuple,set) optional):
-                The resource parts for you want to retrieve.
-                If not provide, use default public parts.
-                You can pass this with single part str, comma-separated parts str or a list,tuple,set of parts.
-            video_id (str, Optional):
-                Specifies that the request should return only the playlist items that contain the specified video.
-            count (int, optional):
-                Control how many items per page will be retreived.
-                Default is 5.
-            return_json(bool, optional):
-                The return data type. If you set True JSON data will be returned.
-                False will return a pyyoutube.PlayListItemApiResponse instance.
-        Returns:
-            PlaylistItemListResponse or original data
-        """
-        args = {
-            "playlistId": playlist_id,
-            "part": enf_parts(resource="playlistItems", value=parts),
-            "maxResults": count,
-        }
-        if video_id is not None:
-            args["video_id"] = video_id
-
-        res_data: Optional[dict] = None
-        current_items: List[dict] = []
-        next_page_token: Optional[str] = None
-        while True:
-            prev_page_token, next_page_token, data = self.paged_by_page_token(
-                resource="playlistItems", args=args, page_token=next_page_token
-            )
-            items = self._parse_data(data)
-            current_items.extend(items)
-            if res_data is None:
-                res_data = data
-            if next_page_token is None:
-                break
-
-        res_data["items"] = current_items
-        if not return_json:
-            res_data = PlaylistItemListResponse.from_dict(res_data)
-        return res_data
-
     def get_video_by_id(
         self,
         *,

--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -672,6 +672,7 @@ class Api(object):
             count (int, optional):
                 The count will retrieve playlist items data.
                 Default is 5.
+                If you want to get all items for the playlist. Provide this with None.
             limit (int, optional):
                 The maximum number of items each request retrieve.
                 For playlistItem, this should not be more than 50.
@@ -683,10 +684,15 @@ class Api(object):
             PlaylistItemListResponse or original data
         """
 
+        if count is None:
+            limit = 50  # this is the most count for per request.
+        else:
+            limit = min(count, limit)
+
         args = {
             "playlistId": playlist_id,
             "part": enf_parts(resource="playlistItems", value=parts),
-            "maxResults": min(count, limit),
+            "maxResults": limit,
         }
         if video_id is not None:
             args["videoId"] = video_id
@@ -706,9 +712,12 @@ class Api(object):
                 res_data = data
             if next_page_token is None:
                 break
-            if now_items_count >= count:
-                break
-        res_data["items"] = current_items[:count]
+            if count is not None:
+                if now_items_count >= count:
+                    current_items = current_items[:count]
+                    break
+
+        res_data["items"] = current_items
         if return_json:
             return res_data
         else:

--- a/tests/apis/test_playlist_items.py
+++ b/tests/apis/test_playlist_items.py
@@ -97,6 +97,19 @@ class ApiPlaylistItemTest(unittest.TestCase):
                 "UExPVTJYTFl4bXNJS3BhVjhoMEFHRTA1c28wZkF3d2ZUdy41NkI0NEY2RDEwNTU3Q0M2",
             )
 
+        # test get all items
+        with responses.RequestsMock() as m:
+            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_1)
+            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_2)
+
+            res_by_playlist = self.api.get_playlist_items(
+                playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",
+                parts="id,snippet",
+                count=None,
+            )
+            self.assertEqual(res_by_playlist.pageInfo.totalResults, 13)
+            self.assertEqual(len(res_by_playlist.items), 13)
+
         # test filter
         with responses.RequestsMock() as m:
             m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_FILTER)


### PR DESCRIPTION
Hey there, nice module you got here.

So unless I'm missing something very obvious... there's no way to get all the items in a playlist. You're limited by `maxResults` if we'd use `get_playlist_items()` so I added a function called `get_playlist_all_items()` that isn't limited by this. I'm using it on playlists larger than 50 so I needed this functionality. Feel free to use the function... or not :)

Thanks anyway.