### PR TITLE
Added support for page tokens in `get_playlist_items()`

### DIFF
--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -669,6 +669,7 @@ class Api(object):
         video_id: Optional[str] = None,
         count: Optional[int] = 5,
         limit: Optional[int] = 5,
+        page_token: Optional[str] = None,
         return_json: Optional[bool] = False,
     ):
         """
@@ -691,6 +692,9 @@ class Api(object):
                 The maximum number of items each request retrieve.
                 For playlistItem, this should not be more than 50.
                 Default is 5
+            page_token
+                The token of the page to retrieve.
+                Use this to get more than 50 items.
             return_json(bool, optional):
                 The return data type. If you set True JSON data will be returned.
                 False will return a pyyoutube.PlayListItemApiResponse instance.
@@ -710,6 +714,9 @@ class Api(object):
         }
         if video_id is not None:
             args["videoId"] = video_id
+        
+        if page_token is not None:
+            args["pageToken"] = page_token
 
         res_data = self.paged_by_page_token(
             resource="playlistItems", args=args, count=count

--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -714,7 +714,7 @@ class Api(object):
         }
         if video_id is not None:
             args["videoId"] = video_id
-        
+
         if page_token is not None:
             args["pageToken"] = page_token
 

--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -423,6 +423,7 @@ class Api(object):
             data = self._parse_response(resp)  # origin response
             # set page token
             page_token = data.get("nextPageToken")
+            prev_page_token = data.get("prevPageToken")
 
             # parse results.
             items = self._parse_data(data)
@@ -439,6 +440,10 @@ class Api(object):
             if page_token is None:
                 break
         res_data["items"] = current_items
+
+        # use last request page token
+        res_data["nextPageToken"] = page_token
+        res_data["prevPageToken"] = prev_page_token
         return res_data
 
     def get_channel_info(
@@ -692,9 +697,10 @@ class Api(object):
                 The maximum number of items each request retrieve.
                 For playlistItem, this should not be more than 50.
                 Default is 5
-            page_token
-                The token of the page to retrieve.
-                Use this to get more than 50 items.
+            page_token(str, optional):
+                The token of the page of playlist items result to retrieve.
+                You can use this retrieve point result page directly.
+                And you should know about the the result set for YouTube.
             return_json(bool, optional):
                 The return data type. If you set True JSON data will be returned.
                 False will return a pyyoutube.PlayListItemApiResponse instance.

--- a/tests/apis/test_playlist_items.py
+++ b/tests/apis/test_playlist_items.py
@@ -126,3 +126,15 @@ class ApiPlaylistItemTest(unittest.TestCase):
                 res_by_filter["items"][0]["snippet"]["resourceId"]["videoId"],
                 "VCv-KKIkLns",
             )
+
+        # test use page token
+        with responses.RequestsMock() as m:
+            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_2)
+
+            res_by_playlist = self.api.get_playlist_items(
+                playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",
+                parts="id,snippet",
+                page_token="CAoQAA",
+                count=3,
+            )
+            self.assertEqual(len(res_by_playlist.items), 3)


### PR DESCRIPTION
Added an extra parameter to `get_playlist_items()` to allow using page tokens. This could be used in conjunction with `nextPageToken` to get more than 50 videos from the playlist.

Of course, the user will have to keep in mind their API usage, and it would make sense for there to be a warning about that in the documentation.