### PR TITLE
Relative imports, create constants, use lowercase for attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all: help clean lint test
+all: help clean lint test check
+
+FOLDERS=tests pyyoutube
 
 .PHONY: all
 
@@ -38,10 +40,14 @@ docs:
 	$(MAKE) -C docs html
 
 lint:
-	black .
+	isort ${FOLDERS} 
+	black ${FOLDERS}
 
-lint-check:
-	black --check .
+check:
+	isort --df -c ${FOLDERS}
+	black ${FOLDERS} --check
+	flake8 ${FOLDERS}
+	mypy ${FOLDERS}
 
 test:
 	pytest -s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,8 @@ pytest-cov = "^2.10.1"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+[tool.black]
+line-length = 90
+target-version = ['py39']
+preview = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=pyyoutube --cov-report xml
+testpaths=tests/

--- a/pyyoutube/api.py
+++ b/pyyoutube/api.py
@@ -9,8 +9,8 @@ from requests.auth import HTTPBasicAuth
 from requests.models import Response
 from requests_oauthlib.oauth2_session import OAuth2Session
 
-from pyyoutube.error import ErrorCode, ErrorMessage, PyYouTubeException
-from pyyoutube.models import (
+from .error import ErrorCode, ErrorMessage, PyYouTubeException
+from .models import (
     AccessToken,
     UserProfile,
     ActivityListResponse,
@@ -31,7 +31,7 @@ from pyyoutube.models import (
     MembershipsLevelListResponse,
     VideoAbuseReportReasonListResponse,
 )
-from pyyoutube.utils.params_checker import enf_comma_separated, enf_parts
+from .utils.params_checker import enf_comma_separated, enf_parts
 
 
 class Api(object):
@@ -583,9 +583,7 @@ class Api(object):
         if page_token is not None:
             args["pageToken"] = page_token
 
-        res_data = self.paged_by_page_token(
-            resource="activities", args=args, count=count
-        )
+        res_data = self.paged_by_page_token(resource="activities", args=args, count=count)
 
         if return_json:
             return res_data
@@ -665,9 +663,7 @@ class Api(object):
         if page_token is not None:
             args["pageToken"] = page_token
 
-        res_data = self.paged_by_page_token(
-            resource="activities", args=args, count=count
-        )
+        res_data = self.paged_by_page_token(resource="activities", args=args, count=count)
 
         if return_json:
             return res_data
@@ -1122,7 +1118,10 @@ class Api(object):
             raise PyYouTubeException(
                 ErrorMessage(
                     status_code=ErrorCode.MISSING_PARAMS,
-                    message=f"Specify at least one of all_to_channel_id, channel_id or video_id",
+                    message=(
+                        f"Specify at least one of all_to_channel_id, channel_id or"
+                        f" video_id"
+                    ),
                 )
             )
 
@@ -1562,9 +1561,7 @@ class Api(object):
         if page_token is not None:
             args["pageToken"] = page_token
 
-        res_data = self.paged_by_page_token(
-            resource="playlists", args=args, count=count
-        )
+        res_data = self.paged_by_page_token(resource="playlists", args=args, count=count)
         if return_json:
             return res_data
         else:
@@ -2164,7 +2161,9 @@ class Api(object):
             raise PyYouTubeException(
                 ErrorMessage(
                     status_code=ErrorCode.MISSING_PARAMS,
-                    message=f"Must specify at least one of mine,recent_subscriber,subscriber.",
+                    message=(
+                        f"Must specify at least one of mine,recent_subscriber,subscriber."
+                    ),
                 )
             )
 

--- a/pyyoutube/client.py
+++ b/pyyoutube/client.py
@@ -71,14 +71,14 @@ class Client:
 
     def __init__(
         self,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
-        api_key: Optional[str] = None,
-        timeout: Optional[int] = None,
-        proxies: Optional[dict] = None,
-        headers: Optional[dict] = None,
+        client_id: str = "",
+        client_secret: str = "",
+        access_token: str = "",
+        refresh_token: str = "",
+        api_key: str = "",
+        timeout: int = constants.DEFAULT_TIMEOUT,
+        proxies: Dict = {},
+        headers: Dict = {},
     ) -> None:
         """Class initial
 
@@ -116,15 +116,28 @@ class Client:
         self.merge_headers()
 
         # Auth settings
-        if not (
-            (self.client_id and self.client_secret) or self.api_key or self.access_token
-        ):
+        if self.has_not_authentification_credentials():
             raise PyYouTubeException(
                 ErrorMessage(
                     status_code=ErrorCode.MISSING_PARAMS,
                     message="Must specify either client key info or api key.",
                 )
             )
+
+    def has_neither_client_id_or_secret(self) -> bool:
+        return not bool(self.client_id and self.client_secret)
+
+    def has_not_api_key(self) -> bool:
+        return not bool(self.api_key)
+
+    def has_not_access_token(self) -> bool:
+        return not bool(self.access_token)
+
+    def has_not_authentification(self) -> bool:
+        return self.has_not_access_token() or self.has_not_api_key()
+
+    def has_not_authentification_credentials(self) -> bool:
+        return self.has_neither_client_id_or_secret() or self.has_not_authentification()
 
     def merge_headers(self):
         """Merge custom headers to session."""
@@ -204,7 +217,7 @@ class Client:
 
         # Add credentials to request
         if enforce_auth:
-            if self.api_key is None and self.access_token is None:
+            if not self.api_key and not self.access_token:
                 raise PyYouTubeException(
                     ErrorMessage(
                         status_code=ErrorCode.MISSING_PARAMS,

--- a/pyyoutube/constants.py
+++ b/pyyoutube/constants.py
@@ -1,0 +1,52 @@
+import os
+import httplib2
+
+BASE_URL = "https://www.googleapis.com/youtube/v3/"
+AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+EXCHANGE_ACCESS_TOKEN_URL = "https://oauth2.googleapis.com/token"
+USER_INFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo"
+
+DEFAULT_REDIRECT_URI = "https://localhost/"
+
+UPLOAD_SCOPE = "https://www.googleapis.com/auth/youtube.upload"
+FULL_ACCESS_SCOPE = "https://www.googleapis.com/auth/youtube"
+PARTNER_SCOPE = "https://www.googleapis.com/auth/youtubepartner"
+READ_WRITE_SSL_SCOPE = "https://www.googleapis.com/auth/youtube.force-ssl"
+
+ALL_SCOPES = (
+    UPLOAD_SCOPE,
+    FULL_ACCESS_SCOPE,
+    PARTNER_SCOPE,
+    READ_WRITE_SSL_SCOPE,
+)
+
+DEFAULT_SCOPE = (
+    FULL_ACCESS_SCOPE,
+    "https://www.googleapis.com/auth/userinfo.profile",
+)
+
+DEFAULT_STATE = "PyYouTube"
+DEFAULT_TIMEOUT = 10
+DEFAULT_QUOTA = 10000  # this quota reset at 00:00:00(GMT-7) every day.
+RETRIABLE_EXCEPTIONS = (httplib2.HttpLib2Error, IOError)
+RETRIABLE_STATUS_CODES = [500, 502, 503, 504]
+DEFAULT_CLIENT_SECRETS_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "./client_secrets.json")
+)
+
+API_SERVICE_NAME = "youtube"
+CURRENT_API_VERSION = "v3"
+
+MISSING_CLIENT_SECRETS_MESSAGE = (
+    """
+    WARNING: Please configure OAuth 2.0
+    To make this sample run you will need to populate the client_secrets.json file
+    found at:
+        %s
+    with information from the API Console
+    https://console.developers.google.com/
+    For more information about the client_secrets.json file format, please visit:
+    https://developers.google.com/api-client-library/python/guide/aaa_client_secrets
+    """
+    % DEFAULT_CLIENT_SECRETS_FILE
+)

--- a/tests/apis/test_activities.py
+++ b/tests/apis/test_activities.py
@@ -7,18 +7,18 @@ import pyyoutube
 
 
 class ApiActivitiesTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/activities/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/activities"
+    base_path = "testdata/apidata/activities/"
+    base_url = "https://www.googleapis.com/youtube/v3/activities"
 
-    with open(BASE_PATH + "activities_by_channel_p1.json", "rb") as f:
-        ACTIVITIES_CHANNEL_P1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "activities_by_channel_p2.json", "rb") as f:
-        ACTIVITIES_CHANNEL_P2 = json.loads(f.read().decode("utf-8"))
+    with open(f"{base_path}activities_by_channel_p1.json", "rb") as f:
+        activities_channel_p1 = json.loads(f.read().decode("utf-8"))
+    with open(f"{base_path}activities_by_channel_p2.json", "rb") as f:
+        activities_channel_p2 = json.loads(f.read().decode("utf-8"))
 
-    with open(BASE_PATH + "activities_by_mine_p1.json", "rb") as f:
-        ACTIVITIES_MINE_P1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "activities_by_mine_p2.json", "rb") as f:
-        ACTIVITIES_MINE_P2 = json.loads(f.read().decode("utf-8"))
+    with open(f"{base_path}activities_by_mine_p1.json", "rb") as f:
+        activities_mine_p1 = json.loads(f.read().decode("utf-8"))
+    with open(f"{base_path}activities_by_mine_p2.json", "rb") as f:
+        activities_mine_p2 = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
         self.api = pyyoutube.Api(api_key="api key")
@@ -31,8 +31,8 @@ class ApiActivitiesTest(unittest.TestCase):
 
         # test get all activities
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.ACTIVITIES_CHANNEL_P1)
-            m.add("GET", self.BASE_URL, json=self.ACTIVITIES_CHANNEL_P2)
+            m.add("GET", self.base_url, json=self.activities_channel_p1)
+            m.add("GET", self.base_url, json=self.activities_channel_p2)
 
             res = self.api.get_activities_by_channel(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
@@ -46,7 +46,7 @@ class ApiActivitiesTest(unittest.TestCase):
 
         # test get by page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.ACTIVITIES_CHANNEL_P2)
+            m.add("GET", self.base_url, json=self.activities_channel_p2)
 
             res = self.api.get_activities_by_channel(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
@@ -64,8 +64,8 @@ class ApiActivitiesTest(unittest.TestCase):
 
         # test get all activities
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.ACTIVITIES_MINE_P1)
-            m.add("GET", self.BASE_URL, json=self.ACTIVITIES_MINE_P2)
+            m.add("GET", self.base_url, json=self.activities_mine_p1)
+            m.add("GET", self.base_url, json=self.activities_mine_p2)
 
             res = self.api_with_access_token.get_activities_by_me(
                 parts="id,snippet",
@@ -78,7 +78,7 @@ class ApiActivitiesTest(unittest.TestCase):
 
         # test page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.ACTIVITIES_MINE_P2)
+            m.add("GET", self.base_url, json=self.activities_mine_p2)
 
             res = self.api_with_access_token.get_activities_by_me(
                 parts="id,snippet",

--- a/tests/apis/test_auth.py
+++ b/tests/apis/test_auth.py
@@ -11,9 +11,9 @@ class TestOAuthApi(unittest.TestCase):
     base_path = "testdata/apidata/"
 
     with open(f"{base_path}access_token.json", "rb") as f:
-        ACCESS_TOKEN_INFO = json.loads(f.read().decode("utf-8"))
+        access_token_info = json.loads(f.read().decode("utf-8"))
     with open(f"{base_path}user_profile.json", "rb") as f:
-        USER_PROFILE_INFO = json.loads(f.read().decode("utf-8"))
+        user_profile_info = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
         self.api = pyyoutube.Api(client_id="xx", client_secret="xx")
@@ -35,7 +35,7 @@ class TestOAuthApi(unittest.TestCase):
             self.api.refresh_token()
 
         with responses.RequestsMock() as m:
-            m.add("POST", self.api.EXCHANGE_ACCESS_TOKEN_URL, json=self.ACCESS_TOKEN_INFO)
+            m.add("POST", self.api.EXCHANGE_ACCESS_TOKEN_URL, json=self.access_token_info)
             token = self.api.generate_access_token(
                 authorization_response=redirect_response,
             )
@@ -60,7 +60,7 @@ class TestOAuthApi(unittest.TestCase):
 
         self.api._access_token = "access_token"
         with responses.RequestsMock() as m:
-            m.add("GET", self.api.USER_INFO_URL, json=self.USER_PROFILE_INFO)
+            m.add("GET", self.api.USER_INFO_URL, json=self.user_profile_info)
             profile = self.api.get_profile()
             self.assertEqual(profile.given_name, "kun")
 

--- a/tests/apis/test_auth.py
+++ b/tests/apis/test_auth.py
@@ -8,11 +8,11 @@ import pyyoutube
 
 
 class TestOAuthApi(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/"
+    base_path = "testdata/apidata/"
 
-    with open(BASE_PATH + "access_token.json", "rb") as f:
+    with open(f"{base_path}access_token.json", "rb") as f:
         ACCESS_TOKEN_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "user_profile.json", "rb") as f:
+    with open(f"{base_path}user_profile.json", "rb") as f:
         USER_PROFILE_INFO = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -35,9 +35,7 @@ class TestOAuthApi(unittest.TestCase):
             self.api.refresh_token()
 
         with responses.RequestsMock() as m:
-            m.add(
-                "POST", self.api.EXCHANGE_ACCESS_TOKEN_URL, json=self.ACCESS_TOKEN_INFO
-            )
+            m.add("POST", self.api.EXCHANGE_ACCESS_TOKEN_URL, json=self.ACCESS_TOKEN_INFO)
             token = self.api.generate_access_token(
                 authorization_response=redirect_response,
             )

--- a/tests/apis/test_captions.py
+++ b/tests/apis/test_captions.py
@@ -7,12 +7,12 @@ import pyyoutube
 
 
 class ApiCaptionsTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/captions/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/captions"
+    base_path = "testdata/apidata/captions/"
+    base_url = "https://www.googleapis.com/youtube/v3/captions"
 
-    with open(BASE_PATH + "captions_by_video.json", "rb") as f:
+    with open(f"{base_path}captions_by_video.json", "rb") as f:
         CAPTIONS_BY_VIDEO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "captions_filter_by_id.json", "rb") as f:
+    with open(f"{base_path}captions_filter_by_id.json", "rb") as f:
         CAPTIONS_FILTER_ID = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -30,7 +30,7 @@ class ApiCaptionsTest(unittest.TestCase):
 
         # test by video
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.CAPTIONS_BY_VIDEO)
+            m.add("GET", self.base_url, json=self.CAPTIONS_BY_VIDEO)
 
             res = self.api_with_access_token.get_captions_by_video(
                 video_id=video_id,
@@ -42,7 +42,7 @@ class ApiCaptionsTest(unittest.TestCase):
 
         # test filter id
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.CAPTIONS_FILTER_ID)
+            m.add("GET", self.base_url, json=self.CAPTIONS_FILTER_ID)
 
             res = self.api_with_access_token.get_captions_by_video(
                 video_id=video_id,

--- a/tests/apis/test_categories.py
+++ b/tests/apis/test_categories.py
@@ -7,14 +7,14 @@ import pyyoutube
 
 
 class ApiVideoCategoryTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/categories/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/videoCategories"
+    base_path = "testdata/apidata/categories/"
+    base_url = "https://www.googleapis.com/youtube/v3/videoCategories"
 
-    with open(BASE_PATH + "video_category_single.json", "rb") as f:
+    with open(f"{base_path}video_category_single.json", "rb") as f:
         VIDEO_CATEGORY_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_category_multi.json", "rb") as f:
+    with open(f"{base_path}video_category_multi.json", "rb") as f:
         VIDEO_CATEGORY_MULTI = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_category_by_region.json", "rb") as f:
+    with open(f"{base_path}video_category_by_region.json", "rb") as f:
         VIDEO_CATEGORY_BY_REGION = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -29,9 +29,9 @@ class ApiVideoCategoryTest(unittest.TestCase):
             self.api.get_video_categories(category_id="id", parts="id,not_part")
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEO_CATEGORY_SINGLE)
-            m.add("GET", self.BASE_URL, json=self.VIDEO_CATEGORY_MULTI)
-            m.add("GET", self.BASE_URL, json=self.VIDEO_CATEGORY_BY_REGION)
+            m.add("GET", self.base_url, json=self.VIDEO_CATEGORY_SINGLE)
+            m.add("GET", self.base_url, json=self.VIDEO_CATEGORY_MULTI)
+            m.add("GET", self.base_url, json=self.VIDEO_CATEGORY_BY_REGION)
 
             res_by_single = self.api.get_video_categories(
                 category_id="17",

--- a/tests/apis/test_channel_sections.py
+++ b/tests/apis/test_channel_sections.py
@@ -6,14 +6,14 @@ import responses
 
 
 class ApiChannelSectionTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/channel_sections/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/channelSections"
+    base_path = "testdata/apidata/channel_sections/"
+    base_url = "https://www.googleapis.com/youtube/v3/channelSections"
 
-    with open(BASE_PATH + "channel_sections_by_id.json", "rb") as f:
+    with open(f"{base_path}channel_sections_by_id.json", "rb") as f:
         CHANNEL_SECTIONS_BY_ID = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_sections_by_ids.json", "rb") as f:
+    with open(f"{base_path}channel_sections_by_ids.json", "rb") as f:
         CHANNEL_SECTIONS_BY_IDS = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_sections_by_channel.json", "rb") as f:
+    with open(f"{base_path}channel_sections_by_channel.json", "rb") as f:
         CHANNEL_SECTIONS_BY_CHANNEL = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -27,8 +27,8 @@ class ApiChannelSectionTest(unittest.TestCase):
         ]
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.CHANNEL_SECTIONS_BY_ID)
-            m.add("GET", self.BASE_URL, json=self.CHANNEL_SECTIONS_BY_IDS)
+            m.add("GET", self.base_url, json=self.CHANNEL_SECTIONS_BY_ID)
+            m.add("GET", self.base_url, json=self.CHANNEL_SECTIONS_BY_IDS)
 
             section_res = self.api.get_channel_sections_by_id(
                 section_id=section_id,
@@ -48,7 +48,7 @@ class ApiChannelSectionTest(unittest.TestCase):
         channel_id = "UCa-vrCLQHviTOVnEKDOdetQ"
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.CHANNEL_SECTIONS_BY_CHANNEL)
+            m.add("GET", self.base_url, json=self.CHANNEL_SECTIONS_BY_CHANNEL)
 
             section_by_channel = self.api.get_channel_sections_by_channel(
                 channel_id=channel_id,

--- a/tests/apis/test_channels.py
+++ b/tests/apis/test_channels.py
@@ -8,12 +8,12 @@ import responses
 
 
 class ApiChannelTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/channels"
+    base_path = "testdata/apidata/"
+    base_url = "https://www.googleapis.com/youtube/v3/channels"
 
-    with open(BASE_PATH + "channel_info_single.json", "rb") as f:
+    with open(f"{base_path}channel_info_single.json", "rb") as f:
         CHANNELS_INFO_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_info_multi.json", "rb") as f:
+    with open(f"{base_path}channel_info_multi.json", "rb") as f:
         CHANNELS_INFO_MULTI = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -24,14 +24,14 @@ class ApiChannelTest(unittest.TestCase):
             api = pyyoutube.Api(client_id="id", client_secret="secret")
             api._request("channels", post_args={"a": "a"})
         with responses.RequestsMock() as m:
-            m.add("POST", self.BASE_URL, json={})
+            m.add("POST", self.base_url, json={})
             api = pyyoutube.Api(access_token="access token")
             res = api._request("channels", post_args={"a": "a"})
             self.assertTrue(res)
 
         with self.assertRaises(pyyoutube.PyYouTubeException):
             with responses.RequestsMock() as m:
-                m.add("GET", self.BASE_URL, body=HTTPError("Exception"))
+                m.add("GET", self.base_url, body=HTTPError("Exception"))
                 self.api.get_channel_info(channel_id="channel_id", parts="id,snippet")
 
     # TODO need to separate.
@@ -40,7 +40,7 @@ class ApiChannelTest(unittest.TestCase):
             error_response = json.loads(f.read().decode("utf-8"))
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=error_response, status=400)
+            m.add("GET", self.base_url, json=error_response, status=400)
 
             with self.assertRaises(pyyoutube.PyYouTubeException):
                 self.api.get_channel_info(
@@ -55,7 +55,7 @@ class ApiChannelTest(unittest.TestCase):
             self.api.get_channel_info()
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.CHANNELS_INFO_SINGLE)
+            m.add("GET", self.base_url, json=self.CHANNELS_INFO_SINGLE)
 
             res_by_channel_id = self.api.get_channel_info(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw", parts="id,snippet,statistics"
@@ -73,7 +73,7 @@ class ApiChannelTest(unittest.TestCase):
             self.assertEqual(res_by_mine.items[0].id, "UC_x5XG1OV2P6uZZ5FSM9Ttw")
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.CHANNELS_INFO_MULTI)
+            m.add("GET", self.base_url, json=self.CHANNELS_INFO_MULTI)
 
             res_by_channel_id_list = self.api.get_channel_info(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw,UCK8sQmJBp8GCxrOtXWBpyEA",

--- a/tests/apis/test_comment_threads.py
+++ b/tests/apis/test_comment_threads.py
@@ -6,22 +6,22 @@ import pyyoutube
 
 
 class ApiCommentThreadTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/comment_threads/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/commentThreads"
+    base_path = "testdata/apidata/comment_threads/"
+    base_url = "https://www.googleapis.com/youtube/v3/commentThreads"
 
-    with open(BASE_PATH + "comment_thread_single.json", "rb") as f:
+    with open(f"{base_path}comment_thread_single.json", "rb") as f:
         COMMENT_THREAD_INFO_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_threads_multi.json", "rb") as f:
+    with open(f"{base_path}comment_threads_multi.json", "rb") as f:
         COMMENT_THREAD_INFO_MULTI = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_threads_all_to_me.json", "rb") as f:
+    with open(f"{base_path}comment_threads_all_to_me.json", "rb") as f:
         COMMENT_THREAD_ALL_TO_ME = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_threads_by_channel.json", "rb") as f:
+    with open(f"{base_path}comment_threads_by_channel.json", "rb") as f:
         COMMENT_THREAD_BY_CHANNEL = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_threads_with_search.json", "rb") as f:
+    with open(f"{base_path}comment_threads_with_search.json", "rb") as f:
         COMMENT_THREAD_BY_SEARCH = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_threads_by_video_paged_1.json", "rb") as f:
+    with open(f"{base_path}comment_threads_by_video_paged_1.json", "rb") as f:
         COMMENT_THREAD_BY_VIDEO_P_1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_threads_by_video_paged_2.json", "rb") as f:
+    with open(f"{base_path}comment_threads_by_video_paged_2.json", "rb") as f:
         COMMENT_THREAD_BY_VIDEO_P_2 = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -31,13 +31,11 @@ class ApiCommentThreadTest(unittest.TestCase):
     def testGetCommentThreadById(self) -> None:
         # test parts
         with self.assertRaises(pyyoutube.PyYouTubeException):
-            self.api.get_comment_thread_by_id(
-                comment_thread_id="id", parts="id,not_part"
-            )
+            self.api.get_comment_thread_by_id(comment_thread_id="id", parts="id,not_part")
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_INFO_SINGLE)
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_INFO_MULTI)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_INFO_SINGLE)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_INFO_MULTI)
 
             res_by_single_id = self.api.get_comment_thread_by_id(
                 comment_thread_id="UgxKREWxIgDrw8w2e_Z4AaABAg",
@@ -73,7 +71,7 @@ class ApiCommentThreadTest(unittest.TestCase):
 
         # test with all to channel.
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_ALL_TO_ME)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_ALL_TO_ME)
 
             res_by_all = self.api_with_token.get_comment_threads(
                 all_to_channel_id="UCa-vrCLQHviTOVnEKDOdetQ",
@@ -89,7 +87,7 @@ class ApiCommentThreadTest(unittest.TestCase):
 
         # test with channel
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_CHANNEL)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_CHANNEL)
 
             res_by_channel = self.api.get_comment_threads(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
@@ -101,7 +99,7 @@ class ApiCommentThreadTest(unittest.TestCase):
 
         # test with search
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_SEARCH)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_SEARCH)
 
             res_by_search = self.api.get_comment_threads(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
@@ -118,8 +116,8 @@ class ApiCommentThreadTest(unittest.TestCase):
 
         # test with video
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_VIDEO_P_1)
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_VIDEO_P_2)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_VIDEO_P_1)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_VIDEO_P_2)
 
             res_by_video = self.api.get_comment_threads(
                 video_id="F1UP7wRCPH8",
@@ -131,8 +129,8 @@ class ApiCommentThreadTest(unittest.TestCase):
 
         # test get all items
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_VIDEO_P_1)
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_VIDEO_P_2)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_VIDEO_P_1)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_VIDEO_P_2)
 
             res_by_video = self.api.get_comment_threads(
                 video_id="F1UP7wRCPH8",
@@ -142,7 +140,7 @@ class ApiCommentThreadTest(unittest.TestCase):
 
         # test use page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENT_THREAD_BY_VIDEO_P_2)
+            m.add("GET", self.base_url, json=self.COMMENT_THREAD_BY_VIDEO_P_2)
 
             res_by_video = self.api.get_comment_threads(
                 video_id="F1UP7wRCPH8",

--- a/tests/apis/test_comments.py
+++ b/tests/apis/test_comments.py
@@ -7,16 +7,16 @@ import pyyoutube
 
 
 class ApiCommentTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/comments/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/comments"
+    base_path = "testdata/apidata/comments/"
+    base_url = "https://www.googleapis.com/youtube/v3/comments"
 
-    with open(BASE_PATH + "comments_single.json", "rb") as f:
+    with open(f"{base_path}comments_single.json", "rb") as f:
         COMMENTS_INFO_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comments_multi.json", "rb") as f:
+    with open(f"{base_path}comments_multi.json", "rb") as f:
         COMMENTS_INFO_MULTI = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comments_by_parent_paged_1.json", "rb") as f:
+    with open(f"{base_path}comments_by_parent_paged_1.json", "rb") as f:
         COMMENTS_PAGED_1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comments_by_parent_paged_2.json", "rb") as f:
+    with open(f"{base_path}comments_by_parent_paged_2.json", "rb") as f:
         COMMENTS_PAGED_2 = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -28,8 +28,8 @@ class ApiCommentTest(unittest.TestCase):
             self.api.get_comment_by_id(comment_id="id", parts="id,not_part")
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_INFO_SINGLE)
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_INFO_MULTI)
+            m.add("GET", self.base_url, json=self.COMMENTS_INFO_SINGLE)
+            m.add("GET", self.base_url, json=self.COMMENTS_INFO_MULTI)
 
             res_by_single = self.api.get_comment_by_id(
                 comment_id="UgyUBI0HsgL9emxcZpR4AaABAg",
@@ -56,8 +56,8 @@ class ApiCommentTest(unittest.TestCase):
 
         # test paged
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_PAGED_2)
+            m.add("GET", self.base_url, json=self.COMMENTS_PAGED_1)
+            m.add("GET", self.base_url, json=self.COMMENTS_PAGED_2)
 
             res_by_parent = self.api.get_comments(
                 parent_id="Ugw5zYU6n9pmIgAZWvN4AaABAg",
@@ -73,7 +73,7 @@ class ApiCommentTest(unittest.TestCase):
 
         # test count
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_PAGED_1)
+            m.add("GET", self.base_url, json=self.COMMENTS_PAGED_1)
 
             res_by_parent = self.api.get_comments(
                 parent_id="Ugw5zYU6n9pmIgAZWvN4AaABAg",
@@ -90,8 +90,8 @@ class ApiCommentTest(unittest.TestCase):
 
         # test get all comments
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_PAGED_2)
+            m.add("GET", self.base_url, json=self.COMMENTS_PAGED_1)
+            m.add("GET", self.base_url, json=self.COMMENTS_PAGED_2)
             res_by_parent = self.api.get_comments(
                 parent_id="Ugw5zYU6n9pmIgAZWvN4AaABAg", parts="id,snippet", count=None
             )
@@ -99,7 +99,7 @@ class ApiCommentTest(unittest.TestCase):
 
         # test use page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.COMMENTS_PAGED_2)
+            m.add("GET", self.base_url, json=self.COMMENTS_PAGED_2)
             res_by_parent = self.api.get_comments(
                 parent_id="Ugw5zYU6n9pmIgAZWvN4AaABAg",
                 parts="id,snippet",

--- a/tests/apis/test_i18ns.py
+++ b/tests/apis/test_i18ns.py
@@ -6,13 +6,13 @@ import pyyoutube
 
 
 class ApiI18nTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/i18ns/"
+    base_path = "testdata/apidata/i18ns/"
     REGION_URL = "https://www.googleapis.com/youtube/v3/i18nRegions"
     LANGUAGE_URL = "https://www.googleapis.com/youtube/v3/i18nLanguages"
 
-    with open(BASE_PATH + "regions_res.json", "rb") as f:
+    with open(f"{base_path}regions_res.json", "rb") as f:
         REGIONS_RES = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "language_res.json", "rb") as f:
+    with open(f"{base_path}language_res.json", "rb") as f:
         LANGUAGE_RES = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:

--- a/tests/apis/test_members.py
+++ b/tests/apis/test_members.py
@@ -6,13 +6,13 @@ import pyyoutube
 
 
 class ApiMembersTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/members/"
+    base_path = "testdata/apidata/members/"
     MEMBERS_URL = "https://www.googleapis.com/youtube/v3/members"
     MEMBERSHIP_LEVEL_URL = "https://www.googleapis.com/youtube/v3/membershipsLevels"
 
-    with open(BASE_PATH + "members_data.json", "rb") as f:
+    with open(f"{base_path}members_data.json", "rb") as f:
         MEMBERS_RES = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "membership_levels.json", "rb") as f:
+    with open(f"{base_path}membership_levels.json", "rb") as f:
         MEMBERSHIP_LEVEL_RES = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:

--- a/tests/apis/test_playlist_items.py
+++ b/tests/apis/test_playlist_items.py
@@ -7,18 +7,18 @@ import pyyoutube
 
 
 class ApiPlaylistItemTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/playlist_items/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/playlistItems"
+    base_path = "testdata/apidata/playlist_items/"
+    base_url = "https://www.googleapis.com/youtube/v3/playlistItems"
 
-    with open(BASE_PATH + "playlist_items_single.json", "rb") as f:
+    with open(f"{base_path}playlist_items_single.json", "rb") as f:
         PLAYLIST_ITEM_INFO_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_items_multi.json", "rb") as f:
+    with open(f"{base_path}playlist_items_multi.json", "rb") as f:
         PLAYLIST_ITEM_INFO_MULTI = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_items_paged_1.json", "rb") as f:
+    with open(f"{base_path}playlist_items_paged_1.json", "rb") as f:
         PLAYLIST_ITEM_PAGED_1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_items_paged_2.json", "rb") as f:
+    with open(f"{base_path}playlist_items_paged_2.json", "rb") as f:
         PLAYLIST_ITEM_PAGED_2 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_items_filter_video.json", "rb") as f:
+    with open(f"{base_path}playlist_items_filter_video.json", "rb") as f:
         PLAYLIST_ITEM_FILTER = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -26,17 +26,17 @@ class ApiPlaylistItemTest(unittest.TestCase):
 
     def testGetPlaylistItemById(self) -> None:
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_INFO_SINGLE)
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_INFO_MULTI)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_INFO_SINGLE)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_INFO_MULTI)
 
             res_by_single_id = self.api.get_playlist_item_by_id(
-                playlist_item_id="UExPVTJYTFl4bXNJSlhzSDJodEcxZzBOVWpIR3E2MlE3aS41NkI0NEY2RDEwNTU3Q0M2",
+                playlist_item_id=(
+                    "UExPVTJYTFl4bXNJSlhzSDJodEcxZzBOVWpIR3E2MlE3aS41NkI0NEY2RDEwNTU3Q0M2"
+                ),
                 parts="id,snippet",
                 return_json=True,
             )
-            self.assertEqual(
-                res_by_single_id["kind"], "youtube#playlistItemListResponse"
-            )
+            self.assertEqual(res_by_single_id["kind"], "youtube#playlistItemListResponse")
             self.assertEqual(
                 res_by_single_id["items"][0]["id"],
                 "UExPVTJYTFl4bXNJSlhzSDJodEcxZzBOVWpIR3E2MlE3aS41NkI0NEY2RDEwNTU3Q0M2",
@@ -62,8 +62,8 @@ class ApiPlaylistItemTest(unittest.TestCase):
 
         # test paged
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_2)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_PAGED_1)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_PAGED_2)
 
             res_by_playlist = self.api.get_playlist_items(
                 playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",
@@ -81,7 +81,7 @@ class ApiPlaylistItemTest(unittest.TestCase):
 
         # test count
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_1)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_PAGED_1)
 
             res_by_playlist = self.api.get_playlist_items(
                 playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",
@@ -99,8 +99,8 @@ class ApiPlaylistItemTest(unittest.TestCase):
 
         # test get all items
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_2)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_PAGED_1)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_PAGED_2)
 
             res_by_playlist = self.api.get_playlist_items(
                 playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",
@@ -112,7 +112,7 @@ class ApiPlaylistItemTest(unittest.TestCase):
 
         # test filter
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_FILTER)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_FILTER)
 
             res_by_filter = self.api.get_playlist_items(
                 playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",
@@ -129,7 +129,7 @@ class ApiPlaylistItemTest(unittest.TestCase):
 
         # test use page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLIST_ITEM_PAGED_2)
+            m.add("GET", self.base_url, json=self.PLAYLIST_ITEM_PAGED_2)
 
             res_by_playlist = self.api.get_playlist_items(
                 playlist_id="PLOU2XLYxmsIKpaV8h0AGE05so0fAwwfTw",

--- a/tests/apis/test_playlists.py
+++ b/tests/apis/test_playlists.py
@@ -7,18 +7,18 @@ import pyyoutube
 
 
 class ApiPlaylistTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/playlists/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/playlists"
+    base_path = "testdata/apidata/playlists/"
+    base_url = "https://www.googleapis.com/youtube/v3/playlists"
 
-    with open(BASE_PATH + "playlists_single.json", "rb") as f:
+    with open(f"{base_path}playlists_single.json", "rb") as f:
         PLAYLISTS_INFO_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlists_multi.json", "rb") as f:
+    with open(f"{base_path}playlists_multi.json", "rb") as f:
         PLAYLISTS_INFO_MULTI = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlists_paged_1.json", "rb") as f:
+    with open(f"{base_path}playlists_paged_1.json", "rb") as f:
         PLAYLISTS_PAGED_1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlists_paged_2.json", "rb") as f:
+    with open(f"{base_path}playlists_paged_2.json", "rb") as f:
         PLAYLISTS_PAGED_2 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlists_mine.json", "rb") as f:
+    with open(f"{base_path}playlists_mine.json", "rb") as f:
         PLAYLISTS_MINE = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -27,8 +27,8 @@ class ApiPlaylistTest(unittest.TestCase):
 
     def testGetPlaylistById(self) -> None:
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_INFO_SINGLE)
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_INFO_MULTI)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_INFO_SINGLE)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_INFO_MULTI)
 
             res_by_playlist_id = self.api.get_playlist_by_id(
                 playlist_id="PLOU2XLYxmsIJXsH2htG1g0NUjHGq62Q7i",
@@ -62,9 +62,9 @@ class ApiPlaylistTest(unittest.TestCase):
             self.api.get_playlists()
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_PAGED_2)
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_MINE)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_PAGED_1)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_PAGED_2)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_MINE)
 
             res_by_channel_id = self.api.get_playlists(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
@@ -87,8 +87,8 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test for all items
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_PAGED_2)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_PAGED_1)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_PAGED_2)
 
             res_by_channel_id = self.api.get_playlists(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
@@ -98,7 +98,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test for page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.PLAYLISTS_PAGED_2)
+            m.add("GET", self.base_url, json=self.PLAYLISTS_PAGED_2)
 
             res_by_channel_id = self.api.get_playlists(
                 channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw", count=None, page_token="CAoQAA"

--- a/tests/apis/test_search.py
+++ b/tests/apis/test_search.py
@@ -7,25 +7,25 @@ import pyyoutube
 
 
 class ApiSearchTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/search/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/search"
+    base_path = "testdata/apidata/search/"
+    base_url = "https://www.googleapis.com/youtube/v3/search"
 
     def setUp(self) -> None:
         self.api = pyyoutube.Api(api_key="api key")
 
     def testSearch(self) -> None:
-        with open(self.BASE_PATH + "search_videos_by_channel.json", "rb") as f:
+        with open(f"{self.base_path}search_videos_by_channel.json", "rb") as f:
             search_videos_by_channel = json.loads(f.read().decode("utf-8"))
-        with open(self.BASE_PATH + "search_by_location.json", "rb") as f:
+        with open(f"{self.base_path}search_by_location.json", "rb") as f:
             search_by_location = json.loads(f.read().decode("utf-8"))
-        with open(self.BASE_PATH + "search_by_event.json", "rb") as f:
+        with open(f"{self.base_path}search_by_event.json", "rb") as f:
             search_by_event = json.loads(f.read().decode("utf-8"))
-        with open(self.BASE_PATH + "search_channels.json", "rb") as f:
+        with open(f"{self.base_path}search_channels.json", "rb") as f:
             search_channels = json.loads(f.read().decode("utf-8"))
 
         # test search videos with channel
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_videos_by_channel)
+            m.add("GET", self.base_url, json=search_videos_by_channel)
 
             res = self.api.search(
                 parts="snippet",
@@ -38,7 +38,7 @@ class ApiSearchTest(unittest.TestCase):
 
         # test search locations
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_by_location)
+            m.add("GET", self.base_url, json=search_by_location)
             res = self.api.search(
                 location="21.5922529, -158.1147114",
                 location_radius="10mi",
@@ -56,7 +56,7 @@ class ApiSearchTest(unittest.TestCase):
 
         # test search event
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_by_event)
+            m.add("GET", self.base_url, json=search_by_event)
             res = self.api.search(
                 event_type="live",
                 q="news",
@@ -74,7 +74,7 @@ class ApiSearchTest(unittest.TestCase):
 
         # test search channel
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_channels)
+            m.add("GET", self.base_url, json=search_channels)
 
             res_channels = self.api.search(
                 parts=["snippet"],
@@ -88,9 +88,9 @@ class ApiSearchTest(unittest.TestCase):
             )
 
     def testSearchByKeywords(self) -> None:
-        with open(self.BASE_PATH + "search_by_keywords_p1.json", "rb") as f:
+        with open(f"{self.base_path}search_by_keywords_p1.json", "rb") as f:
             res_p1 = json.loads(f.read().decode("utf-8"))
-        with open(self.BASE_PATH + "search_by_keywords_p2.json", "rb") as f:
+        with open(f"{self.base_path}search_by_keywords_p2.json", "rb") as f:
             res_p2 = json.loads(f.read().decode("utf-8"))
 
         # test parts
@@ -99,8 +99,8 @@ class ApiSearchTest(unittest.TestCase):
 
         # test response
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=res_p1)
-            m.add("GET", self.BASE_URL, json=res_p2)
+            m.add("GET", self.base_url, json=res_p1)
+            m.add("GET", self.base_url, json=res_p2)
 
             res_json = self.api.search_by_keywords(
                 q="surfing", count=30, limit=25, return_json=True
@@ -120,11 +120,11 @@ class ApiSearchTest(unittest.TestCase):
             self.assertEqual(res.items[0].snippet.channelId, "UCeYue9Nbodzg3T1Nt88E3fg")
 
     def testSearchByRelatedToVideoId(self) -> None:
-        with open(self.BASE_PATH + "search_by_related_video.json", "rb") as f:
+        with open(f"{self.base_path}search_by_related_video.json", "rb") as f:
             search_by_related_video = json.loads(f.read().decode("utf-8"))
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_by_related_video)
+            m.add("GET", self.base_url, json=search_by_related_video)
 
             res = self.api.search_by_related_video(
                 related_to_video_id="Ks-_Mh1QhMc",
@@ -140,11 +140,11 @@ class ApiSearchTest(unittest.TestCase):
             self.assertEqual(res.items[0].snippet.channelId, "UCAuUUnT6oDeKwE6v1NGQxug")
 
     def testSearchByDeveloper(self) -> None:
-        with open(self.BASE_PATH + "search_by_developer.json", "rb") as f:
+        with open(f"{self.base_path}search_by_developer.json", "rb") as f:
             search_by_developer = json.loads(f.read().decode("utf-8"))
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_by_developer)
+            m.add("GET", self.base_url, json=search_by_developer)
 
             res_dev = self.api.search_by_developer(
                 parts=["snippet"],
@@ -167,11 +167,11 @@ class ApiSearchTest(unittest.TestCase):
             )
 
     def testSearchByMine(self) -> None:
-        with open(self.BASE_PATH + "search_by_mine.json", "rb") as f:
+        with open(f"{self.base_path}search_by_mine.json", "rb") as f:
             search_by_mine = json.loads(f.read().decode("utf-8"))
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=search_by_mine)
+            m.add("GET", self.base_url, json=search_by_mine)
 
             res_mine = self.api.search_by_mine(
                 parts=["snippet"],

--- a/tests/apis/test_subscriptions.py
+++ b/tests/apis/test_subscriptions.py
@@ -7,24 +7,24 @@ import pyyoutube
 
 
 class ApiPlaylistTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/subscriptions/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/subscriptions"
+    base_path = "testdata/apidata/subscriptions/"
+    base_url = "https://www.googleapis.com/youtube/v3/subscriptions"
 
-    with open(BASE_PATH + "subscription_zero.json", "rb") as f:
+    with open(f"{base_path}subscription_zero.json", "rb") as f:
         SUBSCRIPTIONS_ZERO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_id.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_id.json", "rb") as f:
         SUBSCRIPTIONS_BY_ID = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_channel_p1.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_channel_p1.json", "rb") as f:
         SUBSCRIPTIONS_BY_CHANNEL_P1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_channel_p2.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_channel_p2.json", "rb") as f:
         SUBSCRIPTIONS_BY_CHANNEL_P2 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_channel_with_filter.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_channel_with_filter.json", "rb") as f:
         SUBSCRIPTIONS_BY_CHANNEL_FILTER = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_mine_p1.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_mine_p1.json", "rb") as f:
         SUBSCRIPTIONS_BY_MINE_P1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_mine_p2.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_mine_p2.json", "rb") as f:
         SUBSCRIPTIONS_BY_MINE_P2 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriptions_by_mine_filter.json", "rb") as f:
+    with open(f"{base_path}subscriptions_by_mine_filter.json", "rb") as f:
         SUBSCRIPTIONS_BY_MINE_FILTER = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -39,8 +39,8 @@ class ApiPlaylistTest(unittest.TestCase):
             )
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_ZERO)
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_ID)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_ZERO)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_ID)
 
             res_zero = self.api.get_subscription_by_id(
                 subscription_id=(
@@ -75,8 +75,8 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test count is None
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_CHANNEL_P1)
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_CHANNEL_P2)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_CHANNEL_P1)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_CHANNEL_P2)
 
             res = self.api.get_subscription_by_channel(
                 channel_id="UCAuUUnT6oDeKwE6v1NGQxug",
@@ -88,7 +88,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test count
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_CHANNEL_P1)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_CHANNEL_P1)
 
             res = self.api.get_subscription_by_channel(
                 channel_id="UCAuUUnT6oDeKwE6v1NGQxug",
@@ -100,7 +100,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test filter
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_CHANNEL_P1)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_CHANNEL_P1)
 
             res = self.api.get_subscription_by_channel(
                 channel_id="UCAuUUnT6oDeKwE6v1NGQxug",
@@ -113,7 +113,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test use page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_CHANNEL_P2)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_CHANNEL_P2)
 
             res = self.api.get_subscription_by_channel(
                 channel_id="UCAuUUnT6oDeKwE6v1NGQxug",
@@ -131,8 +131,8 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test get all data
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_MINE_P1)
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_MINE_P2)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_MINE_P1)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_MINE_P2)
 
             sub = self.api_with_access_token.get_subscription_by_me(
                 mine=True,
@@ -149,7 +149,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test count
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_MINE_P1)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_MINE_P1)
 
             sub = self.api_with_access_token.get_subscription_by_me(
                 mine=True,
@@ -165,7 +165,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test filter channel id
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_MINE_FILTER)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_MINE_FILTER)
 
             sub = self.api_with_access_token.get_subscription_by_me(
                 mine=True,
@@ -179,7 +179,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test remain
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_ZERO)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_ZERO)
 
             recent = self.api_with_access_token.get_subscription_by_me(
                 recent_subscriber=True
@@ -193,7 +193,7 @@ class ApiPlaylistTest(unittest.TestCase):
 
         # test get all data
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.SUBSCRIPTIONS_BY_MINE_P2)
+            m.add("GET", self.base_url, json=self.SUBSCRIPTIONS_BY_MINE_P2)
 
             sub = self.api_with_access_token.get_subscription_by_me(
                 mine=True,

--- a/tests/apis/test_video_abuse_reason.py
+++ b/tests/apis/test_video_abuse_reason.py
@@ -6,10 +6,10 @@ import pyyoutube
 
 
 class ApiVideoAbuseReason(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/abuse_reasons/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/videoAbuseReportReasons"
+    base_path = "testdata/apidata/abuse_reasons/"
+    base_url = "https://www.googleapis.com/youtube/v3/videoAbuseReportReasons"
 
-    with open(BASE_PATH + "abuse_reason.json", "rb") as f:
+    with open(f"{base_path}abuse_reason.json", "rb") as f:
         ABUSE_REASON_RES = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -17,15 +17,13 @@ class ApiVideoAbuseReason(unittest.TestCase):
 
     def testGetVideoAbuseReportReason(self) -> None:
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.ABUSE_REASON_RES)
+            m.add("GET", self.base_url, json=self.ABUSE_REASON_RES)
 
             abuse_res = self.api_with_token.get_video_abuse_report_reason(
                 parts=["id", "snippet"],
             )
 
-            self.assertEqual(
-                abuse_res.kind, "youtube#videoAbuseReportReasonListResponse"
-            )
+            self.assertEqual(abuse_res.kind, "youtube#videoAbuseReportReasonListResponse")
             self.assertEqual(len(abuse_res.items), 3)
 
             abuse_res_json = self.api_with_token.get_video_abuse_report_reason(

--- a/tests/apis/test_videos.py
+++ b/tests/apis/test_videos.py
@@ -7,20 +7,20 @@ import pyyoutube
 
 
 class ApiVideoTest(unittest.TestCase):
-    BASE_PATH = "testdata/apidata/videos/"
-    BASE_URL = "https://www.googleapis.com/youtube/v3/videos"
+    base_path = "testdata/apidata/videos/"
+    base_url = "https://www.googleapis.com/youtube/v3/videos"
 
-    with open(BASE_PATH + "videos_info_single.json", "rb") as f:
+    with open(f"{base_path}videos_info_single.json", "rb") as f:
         VIDEOS_INFO_SINGLE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "videos_info_multi.json", "rb") as f:
+    with open(f"{base_path}videos_info_multi.json", "rb") as f:
         VIDEOS_INFO_MULTI = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "videos_chart_paged_1.json", "rb") as f:
+    with open(f"{base_path}videos_chart_paged_1.json", "rb") as f:
         VIDEOS_CHART_PAGED_1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "videos_chart_paged_2.json", "rb") as f:
+    with open(f"{base_path}videos_chart_paged_2.json", "rb") as f:
         VIDEOS_CHART_PAGED_2 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "videos_myrating_paged_1.json", "rb") as f:
+    with open(f"{base_path}videos_myrating_paged_1.json", "rb") as f:
         VIDEOS_MYRATING_PAGED_1 = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "videos_myrating_paged_2.json", "rb") as f:
+    with open(f"{base_path}videos_myrating_paged_2.json", "rb") as f:
         VIDEOS_MYRATING_PAGED_2 = json.loads(f.read().decode("utf-8"))
 
     def setUp(self) -> None:
@@ -32,8 +32,8 @@ class ApiVideoTest(unittest.TestCase):
             self.api.get_video_by_id(video_id="id", parts="id,not_part")
 
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_INFO_SINGLE)
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_INFO_MULTI)
+            m.add("GET", self.base_url, json=self.VIDEOS_INFO_SINGLE)
+            m.add("GET", self.base_url, json=self.VIDEOS_INFO_MULTI)
 
             res_by_single_id = self.api.get_video_by_id(
                 video_id="D-lhorsDlUQ",
@@ -49,9 +49,10 @@ class ApiVideoTest(unittest.TestCase):
             self.assertEqual(
                 video["player"]["embedHtml"],
                 (
-                    '\u003ciframe width="480" height="270" src="//www.youtube.com/embed/D-lhorsDlUQ" '
-                    'frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; '
-                    'picture-in-picture" allowfullscreen\u003e\u003c/iframe\u003e'
+                    '\u003ciframe width="480" height="270"'
+                    ' src="//www.youtube.com/embed/D-lhorsDlUQ" frameborder="0"'
+                    ' allow="accelerometer; autoplay; encrypted-media; gyroscope;'
+                    ' picture-in-picture" allowfullscreen\u003e\u003c/iframe\u003e'
                 ),
             )
 
@@ -68,8 +69,8 @@ class ApiVideoTest(unittest.TestCase):
 
         # test paged
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_CHART_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_CHART_PAGED_2)
+            m.add("GET", self.base_url, json=self.VIDEOS_CHART_PAGED_1)
+            m.add("GET", self.base_url, json=self.VIDEOS_CHART_PAGED_2)
 
             res_by_chart = self.api.get_videos_by_chart(
                 chart="mostPopular",
@@ -88,7 +89,7 @@ class ApiVideoTest(unittest.TestCase):
 
         # test count
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_CHART_PAGED_1)
+            m.add("GET", self.base_url, json=self.VIDEOS_CHART_PAGED_1)
 
             res_by_chart = self.api.get_videos_by_chart(chart="mostPopular", count=3)
             self.assertEqual(res_by_chart.pageInfo.totalResults, 8)
@@ -97,15 +98,15 @@ class ApiVideoTest(unittest.TestCase):
 
         # test get all items
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_CHART_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_CHART_PAGED_2)
+            m.add("GET", self.base_url, json=self.VIDEOS_CHART_PAGED_1)
+            m.add("GET", self.base_url, json=self.VIDEOS_CHART_PAGED_2)
 
             res_by_chart = self.api.get_videos_by_chart(chart="mostPopular", count=None)
             self.assertEqual(res_by_chart.pageInfo.totalResults, 8)
 
         # test use page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_CHART_PAGED_2)
+            m.add("GET", self.base_url, json=self.VIDEOS_CHART_PAGED_2)
 
             res_by_chart = self.api.get_videos_by_chart(
                 chart="mostPopular", count=None, page_token="CAUQAA"
@@ -114,9 +115,7 @@ class ApiVideoTest(unittest.TestCase):
 
     def testGetVideoByMyRating(self) -> None:
         with self.assertRaises(pyyoutube.PyYouTubeException):
-            self.api_with_token.get_videos_by_myrating(
-                rating="like", parts="id,not_part"
-            )
+            self.api_with_token.get_videos_by_myrating(rating="like", parts="id,not_part")
 
         # test need authorization
         with self.assertRaises(pyyoutube.PyYouTubeException):
@@ -124,8 +123,8 @@ class ApiVideoTest(unittest.TestCase):
 
         # test paged
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_MYRATING_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_MYRATING_PAGED_2)
+            m.add("GET", self.base_url, json=self.VIDEOS_MYRATING_PAGED_1)
+            m.add("GET", self.base_url, json=self.VIDEOS_MYRATING_PAGED_2)
 
             res_by_my_rating = self.api_with_token.get_videos_by_myrating(
                 rating="like",
@@ -143,7 +142,7 @@ class ApiVideoTest(unittest.TestCase):
 
         # test count
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_MYRATING_PAGED_1)
+            m.add("GET", self.base_url, json=self.VIDEOS_MYRATING_PAGED_1)
             res_by_my_rating = self.api_with_token.get_videos_by_myrating(
                 rating="like",
                 parts=("id", "snippet", "player"),
@@ -156,8 +155,8 @@ class ApiVideoTest(unittest.TestCase):
 
         # test get all items
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_MYRATING_PAGED_1)
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_MYRATING_PAGED_2)
+            m.add("GET", self.base_url, json=self.VIDEOS_MYRATING_PAGED_1)
+            m.add("GET", self.base_url, json=self.VIDEOS_MYRATING_PAGED_2)
             res_by_my_rating = self.api_with_token.get_videos_by_myrating(
                 rating="like",
                 parts=("id", "snippet", "player"),
@@ -167,7 +166,7 @@ class ApiVideoTest(unittest.TestCase):
 
         # test use page token
         with responses.RequestsMock() as m:
-            m.add("GET", self.BASE_URL, json=self.VIDEOS_MYRATING_PAGED_2)
+            m.add("GET", self.base_url, json=self.VIDEOS_MYRATING_PAGED_2)
 
             res_by_my_rating = self.api_with_token.get_videos_by_myrating(
                 rating="like",

--- a/tests/clients/base.py
+++ b/tests/clients/base.py
@@ -1,16 +1,11 @@
-"""
-    Base class
-"""
-
-
 class BaseTestCase:
-    BASE_PATH = "testdata/apidata"
-    BASE_URL = "https://www.googleapis.com/youtube/v3"
-    RESOURCE = "CHANNELS"
+    base_path = "testdata/apidata"
+    base_url = "https://www.googleapis.com/youtube/v3"
+    resource = "CHANNELS"
 
     @property
     def url(self):
-        return f"{self.BASE_URL}/{self.RESOURCE}"
+        return f"{self.base_url}/{self.resource}"
 
     def load_json(self, filename, helpers):
-        return helpers.load_json(f"{self.BASE_PATH}/{filename}")
+        return helpers.load_json(f"{self.base_path}/{filename}")

--- a/tests/clients/test_activities.py
+++ b/tests/clients/test_activities.py
@@ -6,7 +6,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestActivitiesResource(BaseTestCase):
-    RESOURCE = "activities"
+    resource = "activities"
 
     def test_list(self, helpers, authed_cli):
         with pytest.raises(PyYouTubeException):
@@ -16,9 +16,7 @@ class TestActivitiesResource(BaseTestCase):
             m.add(
                 method="GET",
                 url=self.url,
-                json=self.load_json(
-                    "activities/activities_by_channel_p1.json", helpers
-                ),
+                json=self.load_json("activities/activities_by_channel_p1.json", helpers),
             )
             res = authed_cli.activities.list(
                 parts=["id", "snippet"],

--- a/tests/clients/test_captions.py
+++ b/tests/clients/test_captions.py
@@ -13,7 +13,7 @@ from pyyoutube.media import Media
 
 
 class TestCaptionsResource(BaseTestCase):
-    RESOURCE = "captions"
+    resource = "captions"
 
     def test_list(self, helpers, key_cli):
         with responses.RequestsMock() as m:

--- a/tests/clients/test_channel_sections.py
+++ b/tests/clients/test_channel_sections.py
@@ -7,7 +7,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestChannelBannersResource(BaseTestCase):
-    RESOURCE = "channelSections"
+    resource = "channelSections"
 
     def test_list(self, helpers, authed_cli, key_cli):
         with pytest.raises(PyYouTubeException):

--- a/tests/clients/test_channels.py
+++ b/tests/clients/test_channels.py
@@ -7,7 +7,7 @@ import pyyoutube.models as mds
 
 
 class TestChannelsResource(BaseTestCase):
-    RESOURCE = "channels"
+    resource = "channels"
     channel_id = "UC_x5XG1OV2P6uZZ5FSM9Ttw"
 
     def test_list(self, helpers, authed_cli, key_cli):

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -4,15 +4,15 @@
 import pytest
 
 import responses
-from requests import Response, HTTPError
+from requests import HTTPError
 
 from .base import BaseTestCase
 from pyyoutube import Client, PyYouTubeException
 
 
 class TestClient(BaseTestCase):
-    BASE_PATH = "testdata"
-    RESOURCE = "channels"
+    base_path = "testdata"
+    resource = "channels"
 
     def test_initial(self):
         with pytest.raises(PyYouTubeException):
@@ -20,6 +20,10 @@ class TestClient(BaseTestCase):
 
         cli = Client(api_key="key", headers={"HA": "P"})
         assert cli.session.headers["HA"] == "P"
+
+    def test_convert_json_to_dict(self):
+        result = Client.convert_json_to_dict({"test": "test"})
+        assert result == {"test": "test"}
 
     def test_request(self, key_cli):
         with pytest.raises(PyYouTubeException):

--- a/tests/clients/test_client.py
+++ b/tests/clients/test_client.py
@@ -21,6 +21,19 @@ class TestClient(BaseTestCase):
         cli = Client(api_key="key", headers={"HA": "P"})
         assert cli.session.headers["HA"] == "P"
 
+    def test_has_client_id_and_secret(self):
+        assert Client(api_key="key").has_client_id_and_secret() is False
+        client = Client(api_key="key", client_id="client", client_secret="secret")
+        assert client.has_client_id_and_secret() is True
+
+    def test_has_api_key(self):
+        assert Client().has_api_key() is False
+        assert Client(api_key="key").has_api_key() is True
+
+    def test_has_access_token(self):
+        assert Client(api_key="key").has_access_token() is False
+        assert Client(access_token="access-token").has_access_token() is True
+
     def test_convert_json_to_dict(self):
         result = Client.convert_json_to_dict({"test": "test"})
         assert result == {"test": "test"}

--- a/tests/clients/test_comment_threads.py
+++ b/tests/clients/test_comment_threads.py
@@ -7,7 +7,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestCommentThreadsResource(BaseTestCase):
-    RESOURCE = "commentThreads"
+    resource = "commentThreads"
 
     def test_list(self, helpers, key_cli):
         with pytest.raises(PyYouTubeException):

--- a/tests/clients/test_comments.py
+++ b/tests/clients/test_comments.py
@@ -7,7 +7,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestCommentsResource(BaseTestCase):
-    RESOURCE = "comments"
+    resource = "comments"
 
     def test_list(self, helpers, key_cli):
         with pytest.raises(PyYouTubeException):
@@ -17,17 +17,13 @@ class TestCommentsResource(BaseTestCase):
             m.add(
                 method="GET",
                 url=self.url,
-                json=self.load_json(
-                    "comments/comments_by_parent_paged_1.json", helpers
-                ),
+                json=self.load_json("comments/comments_by_parent_paged_1.json", helpers),
             )
             res = key_cli.comments.list(
                 parts=["id", "snippet"],
                 parent_id="Ugw5zYU6n9pmIgAZWvN4AaABAg",
             )
-            assert (
-                res.items[0].id == "Ugw5zYU6n9pmIgAZWvN4AaABAg.91zT3cYb5B291za6voUoRh"
-            )
+            assert res.items[0].id == "Ugw5zYU6n9pmIgAZWvN4AaABAg.91zT3cYb5B291za6voUoRh"
             assert res.items[0].snippet.parentId == "Ugw5zYU6n9pmIgAZWvN4AaABAg"
 
             res = key_cli.comments.list(

--- a/tests/clients/test_i18n.py
+++ b/tests/clients/test_i18n.py
@@ -4,7 +4,7 @@ from .base import BaseTestCase
 
 
 class TestI18nLanguagesResource(BaseTestCase):
-    RESOURCE = "i18nLanguages"
+    resource = "i18nLanguages"
 
     def test_list(self, helpers, key_cli):
         with responses.RequestsMock() as m:
@@ -20,7 +20,7 @@ class TestI18nLanguagesResource(BaseTestCase):
 
 
 class TestI18nRegionsResource(BaseTestCase):
-    RESOURCE = "i18nRegions"
+    resource = "i18nRegions"
 
     def test_list(self, helpers, key_cli):
         with responses.RequestsMock() as m:

--- a/tests/clients/test_members.py
+++ b/tests/clients/test_members.py
@@ -4,7 +4,7 @@ from .base import BaseTestCase
 
 
 class TestMembersResource(BaseTestCase):
-    RESOURCE = "members"
+    resource = "members"
 
     def test_list(self, helpers, authed_cli):
         with responses.RequestsMock() as m:

--- a/tests/clients/test_membership_levels.py
+++ b/tests/clients/test_membership_levels.py
@@ -4,7 +4,7 @@ from .base import BaseTestCase
 
 
 class TestMembershipLevelsResource(BaseTestCase):
-    RESOURCE = "membershipsLevels"
+    resource = "membershipsLevels"
 
     def test_list(self, helpers, authed_cli):
         with responses.RequestsMock() as m:

--- a/tests/clients/test_playlist_items.py
+++ b/tests/clients/test_playlist_items.py
@@ -7,7 +7,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestPlaylistItemsResource(BaseTestCase):
-    RESOURCE = "playlistItems"
+    resource = "playlistItems"
 
     def test_list(self, helpers, key_cli):
         with pytest.raises(PyYouTubeException):
@@ -30,7 +30,9 @@ class TestPlaylistItemsResource(BaseTestCase):
             assert len(res.items) == 10
 
             res = key_cli.playlistItems.list(
-                playlist_item_id="UExPVTJYTFl4bXNJS3BhVjhoMEFHRTA1c28wZkF3d2ZUdy41NkI0NEY2RDEwNTU3Q0M2",
+                playlist_item_id=(
+                    "UExPVTJYTFl4bXNJS3BhVjhoMEFHRTA1c28wZkF3d2ZUdy41NkI0NEY2RDEwNTU3Q0M2"
+                ),
                 parts=["id", "snippet"],
             )
             assert (

--- a/tests/clients/test_playlists.py
+++ b/tests/clients/test_playlists.py
@@ -7,7 +7,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestPlaylistsResource(BaseTestCase):
-    RESOURCE = "playlists"
+    resource = "playlists"
 
     def test_list(self, helpers, authed_cli, key_cli):
         with pytest.raises(PyYouTubeException):

--- a/tests/clients/test_search.py
+++ b/tests/clients/test_search.py
@@ -4,7 +4,7 @@ from .base import BaseTestCase
 
 
 class TestSearchResource(BaseTestCase):
-    RESOURCE = "search"
+    resource = "search"
 
     def test_list(self, helpers, authed_cli, key_cli):
         with responses.RequestsMock() as m:

--- a/tests/clients/test_subscriptions.py
+++ b/tests/clients/test_subscriptions.py
@@ -7,7 +7,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestSubscriptionsResource(BaseTestCase):
-    RESOURCE = "subscriptions"
+    resource = "subscriptions"
 
     def test_list(self, helpers, key_cli, authed_cli):
         with pytest.raises(PyYouTubeException):

--- a/tests/clients/test_thumbnails.py
+++ b/tests/clients/test_thumbnails.py
@@ -8,7 +8,7 @@ from pyyoutube.media import Media
 
 
 class TestThumbnailsResource(BaseTestCase):
-    RESOURCE = "thumbnails"
+    resource = "thumbnails"
 
     def test_set(self, authed_cli):
         video_id = "zxTVeyG1600"

--- a/tests/clients/test_video_abuse_report_reasons.py
+++ b/tests/clients/test_video_abuse_report_reasons.py
@@ -4,7 +4,7 @@ from .base import BaseTestCase
 
 
 class TestVideoAbuseReportReasonsResource(BaseTestCase):
-    RESOURCE = "videoAbuseReportReasons"
+    resource = "videoAbuseReportReasons"
 
     def test_list(self, helpers, authed_cli):
         with responses.RequestsMock() as m:

--- a/tests/clients/test_video_categories.py
+++ b/tests/clients/test_video_categories.py
@@ -6,7 +6,7 @@ from pyyoutube.error import PyYouTubeException
 
 
 class TestVideoCategoriesResource(BaseTestCase):
-    RESOURCE = "videoCategories"
+    resource = "videoCategories"
 
     def test_list(self, helpers, key_cli):
         with pytest.raises(PyYouTubeException):
@@ -16,9 +16,7 @@ class TestVideoCategoriesResource(BaseTestCase):
             m.add(
                 method="GET",
                 url=self.url,
-                json=self.load_json(
-                    "categories/video_category_by_region.json", helpers
-                ),
+                json=self.load_json("categories/video_category_by_region.json", helpers),
             )
             res = key_cli.videoCategories.list(
                 parts=["snippet"],

--- a/tests/clients/test_videos.py
+++ b/tests/clients/test_videos.py
@@ -10,7 +10,7 @@ from pyyoutube.media import Media
 
 
 class TestVideosResource(BaseTestCase):
-    RESOURCE = "videos"
+    resource = "videos"
 
     def test_list(self, helpers, authed_cli, key_cli):
         with pytest.raises(PyYouTubeException):

--- a/tests/clients/test_watermarks.py
+++ b/tests/clients/test_watermarks.py
@@ -14,7 +14,7 @@ from pyyoutube.media import Media
 
 
 class TestWatermarksResource(BaseTestCase):
-    RESOURCE = "watermarks"
+    resource = "watermarks"
 
     def test_set(self, authed_cli):
         body = mds.Watermark(

--- a/tests/models/test_abuse_reason.py
+++ b/tests/models/test_abuse_reason.py
@@ -5,11 +5,11 @@ import pyyoutube.models as models
 
 
 class AbuseReasonModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/abuse_report_reason/"
+    base_path = "testdata/modeldata/abuse_report_reason/"
 
-    with open(BASE_PATH + "abuse_reason.json", "rb") as f:
+    with open(f"{base_path}abuse_reason.json", "rb") as f:
         ABUSE_REASON = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "abuse_reason_res.json", "rb") as f:
+    with open(f"{base_path}abuse_reason_res.json", "rb") as f:
         ABUSE_REASON_RES = json.loads(f.read().decode("utf-8"))
 
     def testAbuseReason(self) -> None:

--- a/tests/models/test_activities.py
+++ b/tests/models/test_activities.py
@@ -5,15 +5,15 @@ import pyyoutube.models as models
 
 
 class ActivityModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/activities/"
+    base_path = "testdata/modeldata/activities/"
 
-    with open(BASE_PATH + "activity_contentDetails.json", "rb") as f:
+    with open(f"{base_path}activity_contentDetails.json", "rb") as f:
         ACTIVITY_CONTENT_DETAILS = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "activity_snippet.json", "rb") as f:
+    with open(f"{base_path}activity_snippet.json", "rb") as f:
         ACTIVITY_SNIPPET = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "activity.json", "rb") as f:
+    with open(f"{base_path}activity.json", "rb") as f:
         ACTIVITY = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "activity_response.json", "rb") as f:
+    with open(f"{base_path}activity_response.json", "rb") as f:
         ACTIVITY_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testActivityContentDetails(self) -> None:

--- a/tests/models/test_auth_models.py
+++ b/tests/models/test_auth_models.py
@@ -4,10 +4,10 @@ import pyyoutube.models as models
 
 
 class AuthModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/users/"
-    with open(BASE_PATH + "access_token.json", "rb") as f:
+    base_path = "testdata/modeldata/users/"
+    with open(f"{base_path}access_token.json", "rb") as f:
         ACCESS_TOKEN_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "user_profile.json", "rb") as f:
+    with open(f"{base_path}user_profile.json", "rb") as f:
         USER_PROFILE_INFO = json.loads(f.read().decode("utf-8"))
 
     def testAccessToken(self) -> None:

--- a/tests/models/test_captions.py
+++ b/tests/models/test_captions.py
@@ -5,13 +5,13 @@ import pyyoutube.models as models
 
 
 class CaptionModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/captions/"
+    base_path = "testdata/modeldata/captions/"
 
-    with open(BASE_PATH + "caption_snippet.json", "rb") as f:
+    with open(f"{base_path}caption_snippet.json", "rb") as f:
         CAPTION_SNIPPET = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "caption.json", "rb") as f:
+    with open(f"{base_path}caption.json", "rb") as f:
         CAPTION_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "caption_response.json", "rb") as f:
+    with open(f"{base_path}caption_response.json", "rb") as f:
         CAPTION_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testCaptionSnippet(self):

--- a/tests/models/test_category.py
+++ b/tests/models/test_category.py
@@ -5,15 +5,15 @@ import pyyoutube.models as models
 
 
 class CategoryModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/categories/"
+    base_path = "testdata/modeldata/categories/"
 
-    with open(BASE_PATH + "video_category_info.json", "rb") as f:
+    with open(f"{base_path}video_category_info.json", "rb") as f:
         VIDEO_CATEGORY_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_category_response.json", "rb") as f:
+    with open(f"{base_path}video_category_response.json", "rb") as f:
         VIDEO_CATEGORY_RESPONSE = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "guide_category_info.json", "rb") as f:
+    with open(f"{base_path}guide_category_info.json", "rb") as f:
         GUIDE_CATEGORY_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "guide_category_response.json", "rb") as f:
+    with open(f"{base_path}guide_category_response.json", "rb") as f:
         GUIDE_CATEGORY_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testVideoCategory(self) -> None:

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -4,23 +4,23 @@ import pyyoutube.models as models
 
 
 class ChannelModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/channels/"
+    base_path = "testdata/modeldata/channels/"
 
-    with open(BASE_PATH + "channel_branding_settings.json", "rb") as f:
+    with open(f"{base_path}channel_branding_settings.json", "rb") as f:
         BRANDING_SETTINGS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_content_details.json", "rb") as f:
+    with open(f"{base_path}channel_content_details.json", "rb") as f:
         CONTENT_DETAILS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_topic_details.json", "rb") as f:
+    with open(f"{base_path}channel_topic_details.json", "rb") as f:
         TOPIC_DETAILS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_snippet.json", "rb") as f:
+    with open(f"{base_path}channel_snippet.json", "rb") as f:
         SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_statistics.json", "rb") as f:
+    with open(f"{base_path}channel_statistics.json", "rb") as f:
         STATISTICS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_status.json", "rb") as f:
+    with open(f"{base_path}channel_status.json", "rb") as f:
         STATUS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_info.json", "rb") as f:
+    with open(f"{base_path}channel_info.json", "rb") as f:
         CHANNEL_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_api_response.json", "rb") as f:
+    with open(f"{base_path}channel_api_response.json", "rb") as f:
         CHANNEL_API_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testChannelBrandingSettings(self) -> None:

--- a/tests/models/test_channel_sections.py
+++ b/tests/models/test_channel_sections.py
@@ -5,11 +5,11 @@ import pyyoutube.models as models
 
 
 class ChannelSectionModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/channel_sections/"
+    base_path = "testdata/modeldata/channel_sections/"
 
-    with open(BASE_PATH + "channel_section_info.json", "rb") as f:
+    with open(f"{base_path}channel_section_info.json", "rb") as f:
         CHANNEL_SECTION_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "channel_section_response.json", "rb") as f:
+    with open(f"{base_path}channel_section_response.json", "rb") as f:
         CHANNEL_SECTION_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testChannelSection(self) -> None:

--- a/tests/models/test_comments.py
+++ b/tests/models/test_comments.py
@@ -5,13 +5,13 @@ import pyyoutube.models as models
 
 
 class CommentModelModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/comments/"
+    base_path = "testdata/modeldata/comments/"
 
-    with open(BASE_PATH + "comment_snippet.json", "rb") as f:
+    with open(f"{base_path}comment_snippet.json", "rb") as f:
         SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_info.json", "rb") as f:
+    with open(f"{base_path}comment_info.json", "rb") as f:
         COMMENT_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_api_response.json", "rb") as f:
+    with open(f"{base_path}comment_api_response.json", "rb") as f:
         COMMENT_API_INFO = json.loads(f.read().decode("utf-8"))
 
     def testCommentSnippet(self) -> None:
@@ -42,15 +42,15 @@ class CommentModelModelTest(unittest.TestCase):
 
 
 class CommentThreadModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/comments/"
+    base_path = "testdata/modeldata/comments/"
 
-    with open(BASE_PATH + "comment_thread_snippet.json", "rb") as f:
+    with open(f"{base_path}comment_thread_snippet.json", "rb") as f:
         SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_thread_replies.json", "rb") as f:
+    with open(f"{base_path}comment_thread_replies.json", "rb") as f:
         REPLIES_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_thread_info.json", "rb") as f:
+    with open(f"{base_path}comment_thread_info.json", "rb") as f:
         COMMENT_THREAD_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "comment_thread_api_response.json", "rb") as f:
+    with open(f"{base_path}comment_thread_api_response.json", "rb") as f:
         COMMENT_THREAD_API_INFO = json.loads(f.read().decode("utf-8"))
 
     def testCommentThreadSnippet(self) -> None:

--- a/tests/models/test_i18n_models.py
+++ b/tests/models/test_i18n_models.py
@@ -6,15 +6,15 @@ import pyyoutube.models as models
 
 
 class I18nModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/i18ns/"
+    base_path = "testdata/modeldata/i18ns/"
 
-    with open(BASE_PATH + "region_info.json", "rb") as f:
+    with open(f"{base_path}region_info.json", "rb") as f:
         REGION_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "region_res.json", "rb") as f:
+    with open(f"{base_path}region_res.json", "rb") as f:
         REGION_RES = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "language_info.json", "rb") as f:
+    with open(f"{base_path}language_info.json", "rb") as f:
         LANGUAGE_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "language_res.json", "rb") as f:
+    with open(f"{base_path}language_res.json", "rb") as f:
         LANGUAGE_RES = json.loads(f.read().decode("utf-8"))
 
     def testI18nRegion(self) -> None:

--- a/tests/models/test_members.py
+++ b/tests/models/test_members.py
@@ -5,9 +5,9 @@ import pyyoutube.models as models
 
 
 class MemberModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/members/"
+    base_path = "testdata/modeldata/members/"
 
-    with open(BASE_PATH + "member_info.json", "rb") as f:
+    with open(f"{base_path}member_info.json", "rb") as f:
         MEMBER_INFO = json.loads(f.read().decode("utf-8"))
 
     def testMember(self) -> None:
@@ -19,9 +19,9 @@ class MemberModelTest(unittest.TestCase):
 
 
 class MembershipLevelModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/members/"
+    base_path = "testdata/modeldata/members/"
 
-    with open(BASE_PATH + "membership_level.json", "rb") as f:
+    with open(f"{base_path}membership_level.json", "rb") as f:
         MEMBERSHIP_LEVEL_INFO = json.loads(f.read().decode("utf-8"))
 
     def testMembershipLevel(self) -> None:

--- a/tests/models/test_playlist.py
+++ b/tests/models/test_playlist.py
@@ -5,17 +5,17 @@ import pyyoutube.models as models
 
 
 class PlaylistModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/playlists/"
+    base_path = "testdata/modeldata/playlists/"
 
-    with open(BASE_PATH + "playlist_content_details.json", "rb") as f:
+    with open(f"{base_path}playlist_content_details.json", "rb") as f:
         CONTENT_DETAILS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_snippet.json", "rb") as f:
+    with open(f"{base_path}playlist_snippet.json", "rb") as f:
         SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_status.json", "rb") as f:
+    with open(f"{base_path}playlist_status.json", "rb") as f:
         STATUS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_info.json", "rb") as f:
+    with open(f"{base_path}playlist_info.json", "rb") as f:
         PLAYLIST_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_api_response.json", "rb") as f:
+    with open(f"{base_path}playlist_api_response.json", "rb") as f:
         PLAYLIST_RESPONSE_INFO = json.loads(f.read().decode("utf-8"))
 
     def testPlayListContentDetails(self) -> None:

--- a/tests/models/test_playlist_item.py
+++ b/tests/models/test_playlist_item.py
@@ -5,17 +5,17 @@ import pyyoutube.models as models
 
 
 class PlaylistItemModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/playlist_items/"
+    base_path = "testdata/modeldata/playlist_items/"
 
-    with open(BASE_PATH + "playlist_item_content_details.json", "rb") as f:
+    with open(f"{base_path}playlist_item_content_details.json", "rb") as f:
         CONTENT_DETAILS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_item_snippet.json", "rb") as f:
+    with open(f"{base_path}playlist_item_snippet.json", "rb") as f:
         SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_item_status.json", "rb") as f:
+    with open(f"{base_path}playlist_item_status.json", "rb") as f:
         STATUS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_item_info.json", "rb") as f:
+    with open(f"{base_path}playlist_item_info.json", "rb") as f:
         PLAYLIST_ITEM_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "playlist_item_api_response.json", "rb") as f:
+    with open(f"{base_path}playlist_item_api_response.json", "rb") as f:
         PLAYLIST_LIST_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testPlaylistItemContentDetails(self) -> None:

--- a/tests/models/test_search_result.py
+++ b/tests/models/test_search_result.py
@@ -5,15 +5,15 @@ import pyyoutube.models as models
 
 
 class SearchResultModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/search_result/"
+    base_path = "testdata/modeldata/search_result/"
 
-    with open(BASE_PATH + "search_result_id.json", "rb") as f:
+    with open(f"{base_path}search_result_id.json", "rb") as f:
         SEARCH_RES_ID_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "search_result_snippet.json", "rb") as f:
+    with open(f"{base_path}search_result_snippet.json", "rb") as f:
         SEARCH_RES_SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "search_result.json", "rb") as f:
+    with open(f"{base_path}search_result.json", "rb") as f:
         SEARCH_RES_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "search_result_api_response.json", "rb") as f:
+    with open(f"{base_path}search_result_api_response.json", "rb") as f:
         SEARCH_RES_API_INFO = json.loads(f.read().decode("utf-8"))
 
     def testSearchResultId(self):

--- a/tests/models/test_subscriptions.py
+++ b/tests/models/test_subscriptions.py
@@ -4,17 +4,17 @@ import pyyoutube.models as models
 
 
 class SubscriptionModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/subscriptions/"
+    base_path = "testdata/modeldata/subscriptions/"
 
-    with open(BASE_PATH + "snippet.json", "rb") as f:
+    with open(f"{base_path}snippet.json", "rb") as f:
         SNIPPETS = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "contentDetails.json", "rb") as f:
+    with open(f"{base_path}contentDetails.json", "rb") as f:
         CONTENT_DETAILS = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscriberSnippet.json", "rb") as f:
+    with open(f"{base_path}subscriberSnippet.json", "rb") as f:
         SUBSCRIBER_SNIPPET = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "subscription.json", "rb") as f:
+    with open(f"{base_path}subscription.json", "rb") as f:
         SUBSCRIPTION_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "resp.json", "rb") as f:
+    with open(f"{base_path}resp.json", "rb") as f:
         SUBSCRIPTION_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testSubscriptionSnippet(self) -> None:

--- a/tests/models/test_videos.py
+++ b/tests/models/test_videos.py
@@ -5,21 +5,21 @@ import pyyoutube.models as models
 
 
 class VideoModelTest(unittest.TestCase):
-    BASE_PATH = "testdata/modeldata/videos/"
+    base_path = "testdata/modeldata/videos/"
 
-    with open(BASE_PATH + "video_content_details.json", "rb") as f:
+    with open(f"{base_path}video_content_details.json", "rb") as f:
         CONTENT_DETAILS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_topic_details.json", "rb") as f:
+    with open(f"{base_path}video_topic_details.json", "rb") as f:
         TOPIC_DETAILS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_snippet.json", "rb") as f:
+    with open(f"{base_path}video_snippet.json", "rb") as f:
         SNIPPET_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_statistics.json", "rb") as f:
+    with open(f"{base_path}video_statistics.json", "rb") as f:
         STATISTICS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_status.json", "rb") as f:
+    with open(f"{base_path}video_status.json", "rb") as f:
         STATUS_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_info.json", "rb") as f:
+    with open(f"{base_path}video_info.json", "rb") as f:
         VIDEO_INFO = json.loads(f.read().decode("utf-8"))
-    with open(BASE_PATH + "video_api_response.json", "rb") as f:
+    with open(f"{base_path}video_api_response.json", "rb") as f:
         VIDEO_API_RESPONSE = json.loads(f.read().decode("utf-8"))
 
     def testVideoContentDetails(self) -> None:
@@ -88,9 +88,7 @@ class VideoModelTest(unittest.TestCase):
         m = models.Video.from_dict(self.VIDEO_INFO)
 
         self.assertEqual(m.id, "D-lhorsDlUQ")
-        self.assertEqual(
-            m.snippet.title, "What are Actions on Google (Assistant on Air)"
-        )
+        self.assertEqual(m.snippet.title, "What are Actions on Google (Assistant on Air)")
 
     def testVideoListResponse(self) -> None:
         m = models.VideoListResponse.from_dict(self.VIDEO_API_RESPONSE)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -6,11 +6,11 @@ from pyyoutube.error import ErrorCode, ErrorMessage, PyYouTubeException
 
 
 class ErrorTest(unittest.TestCase):
-    BASE_PATH = "testdata/"
-    with open(BASE_PATH + "error_response.json", "rb") as f:
+    base_path = "testdata/"
+    with open(f"{base_path}error_response.json", "rb") as f:
         ERROR_DATA = f.read()
 
-    with open(BASE_PATH + "error_response_simple.json", "rb") as f:
+    with open(f"{base_path}error_response_simple.json", "rb") as f:
         ERROR_DATA_SIMPLE = f.read()
 
     def testResponseError(self) -> None:


### PR DESCRIPTION
Sorry for the big PR. I used the IDE to change the variables name so it affected many files at once.
Instead of using attributes as constants, I moved them into a separated file, and, when actual attributes are used, I lowercased them.