### PR TITLE
chore(build): :art: follow new poetry core namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ pytest = "^6.0.2"
 pytest-cov = "^2.10.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/testdata/modeldata/channels/channel_statistics.json
+++ b/testdata/modeldata/channels/channel_statistics.json
@@ -1,5 +1,5 @@
 {
-  "viewCount": "160361638",
+  "viewCount": 160361638,
   "commentCount": "0",
   "subscriberCount": "1927873",
   "hiddenSubscriberCount": false,

--- a/testdata/modeldata/videos/video_statistics.json
+++ b/testdata/modeldata/videos/video_statistics.json
@@ -1,5 +1,5 @@
 {
-  "viewCount": "8087",
+  "viewCount": 8087,
   "likeCount": "190",
   "dislikeCount": "23",
   "favoriteCount": "0",


### PR DESCRIPTION
Why is this required?

Prior to the release of version 1.1.0, Poetry was a project management tool that included a PEP 517 build backend. This was inefficient and time consuming when a PEP 517 build was required. For example, both pip and tox (with isolated builds) would install Poetry and all dependencies it required. Most of these dependencies are not required when the objective is to simply build either a source or binary distribution of your project.

See: https://github.com/python-poetry/poetry-core
