### PR TITLE
fix(tests): :white_check_mark: compare int to int, not string

### DIFF
--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -59,7 +59,7 @@ class ChannelModelTest(unittest.TestCase):
     def testChannelStatistics(self) -> None:
         m = models.ChannelStatistics.from_dict(self.STATISTICS_INFO)
 
-        self.assertEqual(m.viewCount, "160361638")
+        self.assertEqual(m.viewCount, 160361638)
 
     def testChannelStatus(self) -> None:
         m = models.ChannelStatus.from_dict(self.STATUS_INFO)

--- a/tests/models/test_videos.py
+++ b/tests/models/test_videos.py
@@ -73,7 +73,7 @@ class VideoModelTest(unittest.TestCase):
     def testVideoStatistics(self) -> None:
         m = models.VideoStatistics.from_dict(self.STATISTICS_INFO)
 
-        self.assertEqual(m.viewCount, "8087")
+        self.assertEqual(m.viewCount, 8087)
 
     def testVideoStatus(self) -> None:
         m = models.VideoStatus.from_dict(self.STATUS_INFO)


### PR DESCRIPTION
Apparently unders some circumstances type coersion (that is otherwise orthogonal to the test case)
at the equality statement fails.

This PR makes the tests not rely on that coersion and allows enabling those tests for
packaging in `nixpkgs`.

See the following [code owner solicitaition](https://github.com/NixOS/nixpkgs/pull/242567#discussion_r1264754772).
