### PR TITLE
fix(examples): `get_all_videos_id_by_channel` returning no results

### DIFF
--- a/examples/apis/get_all_videos_id_with_channel_by_search.py
+++ b/examples/apis/get_all_videos_id_with_channel_by_search.py
@@ -11,21 +11,25 @@ API_KEY = "xxx"  # replace this with your api key.
 
 def get_all_videos_id_by_channel(channel_id, limit=50, count=50):
     api = pyyoutube.Api(api_key=API_KEY)
-    res = api.search(channel_id=channel_id, limit=limit, count=count)
-    next_page = res.nextPageToken
+
     videos = []
+    next_page = None
 
-    while next_page:
-        next_page = res.nextPageToken
-        for item in res.items:
-            if item.id.videoId:
-                videos.append(item.id.videoId)
-
+    while True:
         res = api.search(
             channel_id=channel_id,
             limit=limit,
             count=count,
-            page_token=res.nextPageToken,
+            page_token=next_page,
         )
+
+        next_page = res.nextPageToken
+
+        for item in res.items:
+            if item.id.videoId:
+                videos.append(item.id.videoId)
+
+        if not next_page:
+            break
 
     return videos


### PR DESCRIPTION
fixes #174 

Previously if the response of `api.search()` had no `nextPageToken` (channel has less then 50 videos) the `while` loop would not run at all and return an empty list.

changing the `while` loop into a `do-while` loop ensures that code inside the loop is run at least once.