### PR TITLE
fix(enf_parts): remove leading/trailing whitespace from `parts` parameter values

### DIFF
--- a/pyyoutube/utils/params_checker.py
+++ b/pyyoutube/utils/params_checker.py
@@ -83,6 +83,10 @@ def enf_parts(resource: str, value: Optional[Union[str, list, tuple, set]], chec
                 message=f"Parameter (parts) must be single str,comma-separated str,list,tuple or set",
             )
         )
+
+    # Remove leading/trailing whitespaces
+    parts = set({part.strip() for part in parts})
+
     # check parts whether support.
     if check:
         support_parts = RESOURCE_PARTS_MAPPING[resource]


### PR DESCRIPTION
When making a request you can specify the resource parts you want
for example:
```
cli.playlistItems.list(
    playlist_id=id,
    parts="snippet,contentDetails"
)
```

But adding a whitespace between values 
```
cli.playlistItems.list(
    playlist_id=id,
    parts="snippet, contentDetails" # <- note the whitespace
)
```

results in the error message:
`Parts  contentDetails for resource playlistItems not support`
(took me a couple of minutes to notice the extra space :laughing:)

By running `strip()` on each part, leading/trailing whitespaces are ignored.
This also works for list/set/tuple
ie:
```
parts=("snippet"," contentDetails")
parts=["snippet "," contentDetails"]
```