### PR TITLE
deps: isodate upgrade - 0.6 >> 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 python = "^3.6"
 requests = "^2.24.0"
 requests-oauthlib = "^1.3.0"
-isodate = "^0.7.0"
+isodate = "^0.7.2"
 dataclasses-json = [
     {version = "^0.5.3", python = "<3.7"},
     {version = "^0.6.0", python = ">=3.7"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 python = "^3.6"
 requests = "^2.24.0"
 requests-oauthlib = "^1.3.0"
-isodate = "^0.6.0"
+isodate = "^0.7.0"
 dataclasses-json = [
     {version = "^0.5.3", python = "<3.7"},
     {version = "^0.6.0", python = ">=3.7"}


### PR DESCRIPTION
Partial fix for #173

Changes introduced with [`isodate`](https://github.com/gweis/isodate) 0.7 release (according to their `CHANGELOG`):

> 0.7.2 (2024-10-08)
> ------------------
> 
> - drop end of life python versions
> - Don't match garbage characters at the end of parsed strings
> 
> Potentially breaking changes:
> 
> - Fractional seconds are cut off to microseconds (always round down)
> - Allow control over return type of parse_duration
> - Python >= 3.7 required