### PR TITLE
fix(dependencies): remove strict pinning for `requests-oauthlib`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.24.0"
-requests-oauthlib = "=1.3.0,<3.0.0"
+requests-oauthlib = ">=1.3.0,<3.0.0"
 isodate = ">=0.6.0,<=0.7.2"
 dataclasses-json = [
     { version = "^0.5.3", python = "<3.7" },


### PR DESCRIPTION
Strict pinning is not compatible with the `<3.0.0` condition so I am assuming that was unintentionally done in https://github.com/sns-sdks/python-youtube/pull/184

This PR should correctly resolve https://github.com/sns-sdks/python-youtube/issues/173